### PR TITLE
Update for Shairport Sync 2.4

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Emulates an AirPort Express for the purpose of streaming music from iTu
 url='https://github.com/mikebrady/shairport-sync'
 arch=(i686 x86_64 armv6h armv7h)
 license=('custom')
-backup=(etc/conf.d/shairport-sync)
+backup=(etc/shairport-sync.conf)
 install='shairport-sync.install'
 depends=(alsa-lib libdaemon openssl avahi popt libsoxr libconfig)
 makedepends=(git)
@@ -47,6 +47,6 @@ package() {
   install -D -m664 LICENSES "$pkgdir/usr/share/licenses/$pkgname/LICENSE"  
 
   make install
-  [ -e "$pkgdir/etc/shairport-sync.conf" ] || install -D -m644 scripts/shairport-sync.conf "$pkgdir/etc/shairport-sync.conf"
+  install -D -m644 scripts/shairport-sync.conf "$pkgdir/etc/shairport-sync.conf"
   install -D -m644 scripts/shairport-sync.conf "$pkgdir/etc/shairport-sync.conf.sample"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Elia Cereda <eliacereda+arch at gmail dot com>
 
 pkgname=shairport-sync-git
-pkgver=2.1.15.r1.gcf6594d
+pkgver=2.4.r0.g0453080
 pkgrel=1
 pkgdesc='Emulates an AirPort Express for the purpose of streaming music from iTunes and compatible iPods and iPhones'
 url='https://github.com/mikebrady/shairport-sync'
@@ -9,36 +9,33 @@ arch=(i686 x86_64 armv6h armv7h)
 license=('custom')
 backup=(etc/conf.d/shairport-sync)
 install='shairport-sync.install'
-depends=(alsa-lib libdaemon openssl avahi popt libsoxr)
+depends=(alsa-lib libdaemon openssl avahi popt libsoxr libconfig)
 makedepends=(git)
 source=("git+https://github.com/mikebrady/shairport-sync.git"
 	shairport-sync.install
 	shairport-sync.service
-	shairport-sync.conf
-	remove-init.d.patch)
+	shairport-sync.conf)
+
 sha1sums=('SKIP'
           'd51485f3857529b70a29b38814ea60e7dde54ca8'
           'fe62feeef1c947ed6ed3500b7b922dcaf9e8987c'
-          '6c4979abddb4b1c0242a941279d41617ab8d183c'
-          '83ddd76fdb548bf6321e38ff7cabe14bf2bb35d4')
+          '6c4979abddb4b1c0242a941279d41617ab8d183c')
 
 pkgver() {
   cd shairport-sync
-  
+
   git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g'
 }
 
 prepare() {
   cd shairport-sync
-  
-  git apply "$srcdir/remove-init.d.patch"
 }
 
 build() {
   cd shairport-sync
 
   autoreconf -i -f
-  ./configure --with-alsa --with-avahi --with-ssl=openssl --with-soxr --prefix="$pkgdir/usr"
+  ./configure --with-alsa --with-avahi --with-ssl=openssl --with-soxr --without-configfiles --prefix="$pkgdir/usr"
   make
 }
 
@@ -47,8 +44,9 @@ package() {
   install -D -m644 shairport-sync.conf "$pkgdir/etc/conf.d/shairport-sync"
 
   cd shairport-sync
-
   install -D -m664 LICENSES "$pkgdir/usr/share/licenses/$pkgname/LICENSE"  
 
   make install
+  [ -e "$pkgdir/etc/shairport-sync.conf" ] || install -D -m644 scripts/shairport-sync.conf "$pkgdir/etc/shairport-sync.conf"
+  install -D -m644 scripts/shairport-sync.conf "$pkgdir/etc/shairport-sync.conf.sample"
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+#Arch Linux package files for Shairport Sync
+
+This package builds and optionally installs Shairport Sync on Arch Linux. It also creates a user and group to allow Shairport Sync to run as a daemon with the lowest possible privileges.
+
+**Usage**
+
+Download the package:
+```
+$git clone https://github.com/EliaCereda/shairport-sync-PKGBUILD.git
+```
+
+Move into the resulting directory:
+```
+$cd shairport-sync-PKGBUILD
+```
+
+Excute the following command:
+```
+$makepkg -sfi
+```
+to install dependencies (`-s`), download, build and install (`-i`) Shairport Sync, always (`-f`).
+You will need to have `sudo` privileges and you will be asked to enter your password during installation. Do not try to run this script as `root`.
+
+Please refer to the ["Configuring Shairport Sync"](https://github.com/mikebrady/shairport-sync/blob/master/README.md#configuring-shairport-sync)
+for information on how to configure Shairport Sync.

--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ $makepkg -sfi
 to install dependencies (`-s`), download, build and install (`-i`) Shairport Sync, always (`-f`).
 You will need to have `sudo` privileges and you will be asked to enter your password during installation. Do not try to run this script as `root`.
 
+An existing configuration file at `/etc/shairport-sync.conf` will not be overwritten.
+
 Please refer to the ["Configuring Shairport Sync"](https://github.com/mikebrady/shairport-sync/blob/master/README.md#configuring-shairport-sync)
 for information on how to configure Shairport Sync.


### PR DESCRIPTION
Hi there. This is an attempt to update the script for Shairport Sync 2.4. It works for me on a Raspberry Pi 2 running Arch Linux. It removes the patch file, adds the `libconfig` dependency, installs a `shairport-sync.conf` configuration file in `/etc` if necessary (it shouldn't override an existing one). I added a short README file too.

I'm not an expert on these packaging files, so apologies if I've gotten something wrong.
